### PR TITLE
Using afn

### DIFF
--- a/ApiPublisher.js
+++ b/ApiPublisher.js
@@ -113,32 +113,6 @@ ApiPublisher.prototype.sendRemoteApi = function(req,rsp) {
     }) ;
 };
 
-function stringRepresentation(o) {
-    try {
-        return JSON.stringify(o)+o.toString() ;
-    } catch (ex) {
-        return o.toString() ;
-    }
-}
-
-function hashCode(o) {
-    var h = 0;
-    if (o===undefined) return "undefined" ;
-    if (o===null) return "null" ;
-    if (o instanceof Object){
-        return hashCode(Object.keys(o).sort().map(function(k) { return hashCode(k)+hashCode(o[k]) }).join('|')) ;
-    } else {
-        var s = (typeof o)+o.toString() ;
-        for (var i=0; i<s.length; i++)
-            h = (((h << 5) - h) + s.charCodeAt(i)) & 0xFFFFFFFF;
-        return h ;
-    }
-}
-
-function hash(o) {
-    return hashCode(o).toString(36) ;
-}
-
 /**
  * Remote invocation of a local async funcback API. 
  **/
@@ -215,7 +189,7 @@ ApiPublisher.prototype.callRemoteApi = function(name,req,rsp) {
     /* Send an error result, invalidating the cache */
     function errorCB(err,status) {
         if (!(err instanceof Error))
-            err = new Error(err.toString()) ;
+            err = new Error(err.message || err.toString()) ;
 
         var result = {value:{error:err.message,cause:err.stack} ,status:status || 500} ;
 
@@ -225,6 +199,7 @@ ApiPublisher.prototype.callRemoteApi = function(name,req,rsp) {
     return fn.apply(context,args).then(returnCB,errorCB) ;
 };
 
+// Deprecated - this is no longer called internally
 ApiPublisher.prototype.cacheObject = function(obj) {
     return {args:obj.arguments,version:obj.request.apiVersion} ;
 };

--- a/ServerApi.js
+++ b/ServerApi.js
@@ -37,9 +37,8 @@ function callRemoteFuncBack(that,path,args) {
 				} else {
 					if (contentType=="application/json") {
 						var exception = JSON.parse(body,that.reviver) ;
-						var exc = new Error(body) ;
+						var exc = new Error(exception.message || exception.error || exception.toString()) ;
 						Object.defineProperties(exc, getOwnPropertyDescriptions(exception)) ;
-						exc.constructor = Error ;
 						error(exc) ;
 					} else {
 						error(new Error(body)) ;

--- a/index.js
+++ b/index.js
@@ -14,11 +14,17 @@ var remoteApiPath = __dirname+"/www/RemoteApi.js" ;
 
 var remoteApiContent ;
 
+var bundledFunctions = {
+    $asyncbind:nodent.$asyncbind,
+    $asyncspawn:nodent.$asyncspawn,
+    afn$memo:require('afn/memo')
+};
+
 function sendRemoteApi(req,res,next) {
     res.writeHead(200, {'Content-Type': 'application/javascript; charset=utf-8'} );
     if (!remoteApiContent) {
     	remoteApiContent = fs.readFileSync(remoteApiPath).toString() ;
-    	remoteApiContent = remoteApiContent.split(/<@|@>/).map(function(f,i){ return i&1?nodent[f].toString():f}).join("") ;
+    	remoteApiContent = remoteApiContent.split(/<@|@>/).map(function(f,i){ return i&1?bundledFunctions[f].toString():f}).join("") ;
     }
     res.end(remoteApiContent) ;
 }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "apipublisher",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "Async JS API remoting",
   "main": "index.js",
   "scripts": {
     "test": "open http://localhost:1966/ && node test/run-test-client-server.js"
   },
   "dependencies": {
+    "afn": "^1.0.1",
     "nodent": ">=2.6.9"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "open http://localhost:1966/ && node test/run-test-client-server.js"
   },
   "dependencies": {
-    "afn": "^1.0.1",
+    "afn": "^1.0.6",
     "nodent": ">=2.6.9"
   },
   "devDependencies": {

--- a/test/nodented.js
+++ b/test/nodented.js
@@ -6,7 +6,11 @@ var ServerApi = require("../index").ServerApi ;
 var api = await ServerApi.load("http://localhost:1966/testapi") ;
 
 // Make a remote call & display the result.
-console.log("Client delay() is:",JSON.stringify(await api.delay(100))) ;
-console.log("Client always.hello() is:",JSON.stringify(await api.always.hello())) ;
-
+try {
+    console.log("Client delay() is:",JSON.stringify(await api.delay(100))) ;
+    console.log("Client always.hello() is:",JSON.stringify(await api.always.hello())) ;
+    console.log("Client delay(-1) is:",JSON.stringify(await api.delay(-1))) ;
+} catch (ex) {
+    console.log("Client error:",ex.message) ;
+}
 

--- a/test/run-test-client-server.js
+++ b/test/run-test-client-server.js
@@ -14,7 +14,7 @@ server.on('close', function (code) {
 	console.log('Server process exited with code ' + code);
 });
 
-/* Wait a seconds and start the client */
+/* Wait a few seconds and start the client */
 function testServer() {
 	var ServerApi = require("../index").ServerApi ;
 	
@@ -22,6 +22,8 @@ function testServer() {
 	ServerApi.load("http://localhost:1966/testapi").then(function(api){
 		api.delay(200).then(function(result){
 			console.log("Client",JSON.stringify(result)) ;
+		},function(result){
+            console.log("Client(error)",JSON.stringify(result)) ;
 		})
 	}) ;
 	

--- a/test/server.js
+++ b/test/server.js
@@ -40,3 +40,5 @@ console.log("Test server listening on http://localhost:1966/\n") ;
 var log = console.log.bind(console) ;
 console.log("Calling the async API locally, just for show") ;
 testApi.delay(3000).then(log,log) ;
+testApi.delay(3000).then(log,log) ;
+testApi.delay(3000).then(log,log) ;

--- a/test/testapi.js
+++ b/test/testapi.js
@@ -46,5 +46,5 @@ var api = {
 //Example of APIs that resolves WITHOUT a round-trip on the client 
 api.client.clientInstance = ["Matt"] ;
 api.always.clientInstance = [] ;
-
+api.delay.ttl = { server:5000 } ;
 module.exports = api ;

--- a/test/testapi.js
+++ b/test/testapi.js
@@ -27,6 +27,9 @@ var nested = new ApiPublisher({
 
 var api = {
 	delay:async function(period) {
+	    if (period <= 0) {
+	        throw new Error("This is not a time machine") ;
+	    }
 		period = period || 1000 ;
 		var result = {started:Date.now()} ;
 		await after(period) ;

--- a/test/web/index.html
+++ b/test/web/index.html
@@ -5,7 +5,7 @@
 //Nodent on the client requires at "top-level" error handler
 //called $error()
 window.$error = function(ex) {
-	console.error(ex) ;
+	alert(JSON.stringify(ex,null,2)) ;
 }
 
 // Test using client-side JavaScript
@@ -26,5 +26,6 @@ RemoteApi.load("/testapi").then(function(api){
 Testing...
 </div>
 <button id="test">Test again</button>
+<button id="oops">Test errors</button>
 </body>
 </html>

--- a/test/web/nodented.js
+++ b/test/web/nodented.js
@@ -6,8 +6,13 @@ window.remote = await RemoteApi.load("/testapi") ;
 // Set the button's onclick handler to make a remote call
 // and display the result.
 document.getElementById("test").onclick = function() {
-	var result = await remote.delay(300) ;
-	document.getElementById("flutter").innerText = "Flutter was "+result.flutter+" ms." ;
+    var result = await remote.delay(300) ;
+    document.getElementById("flutter").innerText = "Flutter was "+result.flutter+" ms." ;
+}
+
+document.getElementById("oops").onclick = function() {
+    var result = await remote.delay(-1) ;
+    document.getElementById("flutter").innerText = "Flutter was "+result.flutter+" ms." ;
 }
 
 // Test the clientInstance nested APIs are automatically available

--- a/www/RemoteApi.js
+++ b/www/RemoteApi.js
@@ -199,36 +199,37 @@ window.RemoteApi = (function(){
         function StorageCache(name){
             Object.defineProperty(this,"name",{value:'RemoteAPI:'+name,configurable:true,writeable:true}) ;
             Object.defineProperty(this,"storage",{value:storage || window.localStorage}) ;
-            Object.assign(this,JSON.parse(this.storage[this.name]||"{}")) ;
+            this.store = Object.create(null) ;
+            Object.assign(this.store,JSON.parse(this.storage[this.name]||"{}")) ;
         }
         StorageCache.prototype = {
             setStorage:function(){
                 try {
-                    this.storage[this.name] = JSON.stringify(this) ;
+                    this.storage[this.name] = JSON.stringify(this.store) ;
                 } catch (ex) {
                     console.warn("Can't cache API data. Removing old data from localStorage",ex) ;
                     this.storage.removeItem(this.name) ;
                 }
             },
             set:function(k,v){
-                this[k] = v ;
+                this.store[k] = v ;
                 this.setStorage() ;
             },
             get:function(k){
-                return this[k] ;
+                return this.store[k] ;
             },
             remove:function(k){ // Deprecated in favour of delete(), like a Map
                 this.delete(k) ; 
             },
             delete:function(k){
-                delete this[k] ;
+                delete this.store[k] ;
                 if (!this.keys().length)
                     this.storage.removeItem(this.name) ;
                 else
                     this.setStorage() ;
             },
             keys:function(){
-                return Object.keys(this) ;
+                return Object.keys(this.store) ;
             }
         } ;
         return StorageCache ;


### PR DESCRIPTION
Remove all cache management logic and replace with afn.memo()
Ensure consistency in API rejection by combining rejections into ApiError (derived from Error)
Deprecate api.cacheObject()
