### PR TITLE
feat: add ability to send a payload along an error

### DIFF
--- a/ApiPublisher.js
+++ b/ApiPublisher.js
@@ -222,7 +222,7 @@ ApiPublisher.prototype.callRemoteApi = function(name,req,rsp,next) {
         if (!(err instanceof Error))
             err = new Error(err.message || err.toString()) ;
 
-        var result = {value:{error:err.message,cause:err.stack} ,status:status || 500} ;
+        var result = {value:{error:err.message,cause:err.stack,payload:err.payload} ,status:status || 500} ;
 
         sendReturn(result);
     } ;


### PR DESCRIPTION
Scenario: an API checks for conflicts when saving against the most recent snapshot (which can be more recent than the one in the client), if conflicts exist then an error is thrown with `httpStatus: 409` but we also want to send the most recent snapshot to the client, along some other info (conflict positions).

Suggested way of doing this is via an optional `payload` property in the error (which is simply ignored if it's `undefined`).

Edit: feel free to ignore this, I think we can't really have type safety in the client (I don't think we can use `instanceof` there, which would leave us with user defined guards at best, which are not ideal). I've changed the approach. AFAIK TS doesn't have a way to declare thrown error types like e.g. Java does.